### PR TITLE
Add: 增加首页大图位置调整功能

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -150,9 +150,9 @@
 	  <div id="pjax-container"><!-- 开始 pjax-container -->
 	  <header>
 	    <?php if($this->is('post') || $this->is('page')): ?>
-		<div class="index-banner" style="background:url('<?php if($this->fields->banner && $this->fields->banner=!''): ?><?php $this->fields->banner(); ?><?php else: ?><?php $this->options->bannerUrl(); ?><?php endif; ?>') no-repeat;height:<?php $this->options->bannerHeight(); ?>vh;background-size:cover;">
+		<div class="index-banner" style="background:url('<?php if($this->fields->banner && $this->fields->banner=!''): ?><?php $this->fields->banner(); ?><?php else: ?><?php $this->options->bannerUrl(); ?><?php endif; ?>') no-repeat;height:<?php $this->options->bannerHeight(); ?>vh;background-size:cover;<?php $this->options->bannerPosition(); ?>">
 		<?php else: ?>
-	    <div class="index-banner" style="background:url('<?php $this->options->bannerUrl(); ?>') no-repeat;height:<?php $this->options->bannerHeight(); ?>vh;background-size:cover;">
+	    <div class="index-banner" style="background:url('<?php $this->options->bannerUrl(); ?>') no-repeat;height:<?php $this->options->bannerHeight(); ?>vh;background-size:cover;<?php $this->options->bannerPosition(); ?>">
 		<?php endif; ?>
 		  <div class="banner-mask">
 		    <div class="main-container container">

--- a/libs/Options.php
+++ b/libs/Options.php
@@ -93,6 +93,8 @@ function themeConfig($form) {
     $form->addInput($bannerTitle);
 	$bannerIntro = new Typecho_Widget_Helper_Form_Element_Text('bannerIntro', NULL, NULL, _t('介绍'), _t('这里是首页大图标题下的简介<hr>'));
     $form->addInput($bannerIntro);
+    $bannerPosition = new Typecho_Widget_Helper_Form_Element_Select('bannerPosition', array(''=>'默认','background-position:center,center;'=>'垂直水平居中'), '0', '位置', '这里选择首页大图的显示位置，“默认”图片从左上角开始显示，“垂直水平居中”为图片垂直水品居中显示。');
+    $form->addInput($bannerPosition);
 	
 	//pjax
 	$pjax = new Typecho_Widget_Helper_Form_Element_Select('pjax',array('0'=>'关闭','1'=>'开启'),'1','<h2>Pjax 预加载</h2>是否开启','Pjax 预加载功能的开关');


### PR DESCRIPTION
偶然看到了这个主题便决定给自己的站子换上这个主题了
这个主题真的很好看，谢谢作者~~

另外我这里有一个关于首页大图的一个小建议：
不知道是我浏览器的问题还是咋的，首页大图默认是居左的，而一般图片的重点都在图片的中心，这样子的话在一些移动设备上（比如竖屏的手机上）看起来会很别扭
所以就试着加了一个设置，能把首页大图设置成居中显示，这样的话会好看很多
于是就自己试着做了qwq
希望能够被采纳pwp

这是效果图：
（居中前）
![photo_2019-11-14_11-11-55](https://user-images.githubusercontent.com/13681639/68825844-a0dfa200-06d6-11ea-9806-380f3369c804.jpg)

（居中后）
![photo_2019-11-14_11-11-58](https://user-images.githubusercontent.com/13681639/68825855-ab01a080-06d6-11ea-811f-15062955295f.jpg)
